### PR TITLE
Update lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,7 +4076,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4.5.5:
+typescript@4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==


### PR DESCRIPTION
A fresh install of dependencies on `main` using `yarn ci` updates the lockfile in this way. My understanding is that the flags we pass to yarn ci should exit if the lockfile needs to be modified, so not sure what's going on here. I'll continue digging into it, but for now we could update this I think.