### PR TITLE
Port over Notebooks/Code Search update

### DIFF
--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -98,6 +98,49 @@ export const CodeSearchPage: FunctionComponent = () => (
             </div>
         </ContentSection>
 
+        {/* Notebooks */}
+        <ContentSection>
+            <div className="row pt-md-6">
+                <div className="col-lg-6 order-sm-2 mt-4 mt-md-0 container video-container">
+                    <video
+                        className="w-100 h-auto shadow"
+                        autoPlay={true}
+                        muted={true}
+                        loop={true}
+                        playsInline={true}
+                        controls={false}
+                        // GCS does not set cookies, so we don't want Cookiebot to block this video based on consent
+                        data-cookieconsent="ignore"
+                    >
+                        <source
+                            src="https://storage.googleapis.com/sourcegraph-assets/notebooks/Notebooks_Capture_20s.mp4"
+                            type="video/mp4"
+                        />
+                        Creating a Notebook with Sourcegraph
+                    </video>
+                </div>
+                <div className="col-lg-6 order-sm-1">
+                    <h2 className="display-3 font-weight-bold mb-3 mt-4 mt-md-0">
+                        Document and explore code with Notebooks
+                    </h2>
+                    <ul>
+                        <li className="mb-1">
+                            Create living documentation with Markdown and live code queries to get engineers up to speed
+                            on unfamiliar code faster.
+                        </li>
+                        <li className="mb-1">
+                            Navigate through complex parts of your codebase or resolve incidents with collaborative and
+                            shareable notebooks.
+                        </li>
+                        <li className="mb-1">
+                            Embed notebooks anywhere you can embed HTML, like your own internal documentation, so you
+                            can spend less time updating stale docs.
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </ContentSection>
+
         {/* Social proof */}
         <ContentSection className="py-4">
             <div className="row justify-content-center pt-md-4">


### PR DESCRIPTION
This closes #136. It ports over the section for Notebooks recently added to `/code-search`.

### Testing
- Navigate to `/code-search`
- Confirm the added section matches `about`
 